### PR TITLE
DM-31346: Use the DM dev guide's recommendations for linter options

### DIFF
--- a/workflow-templates/lint.yaml
+++ b/workflow-templates/lint.yaml
@@ -21,4 +21,4 @@ jobs:
         run: pip install -r <(curl https://raw.githubusercontent.com/lsst/linting/master/requirements.txt)
 
       - name: Run linter
-        run: flake8
+        run: flake8 --ignore=E133,E226,E228 --max-line-length=110 --max-doc-length=79 --exclude bin,doc,**/*/__init.py,**/*/version.py,tests/.tests


### PR DESCRIPTION
These options are recommended here:

https://developer.lsst.io/python/style.html?highlight=flake8#flake8-command-line-invocation

This invocation at least isn't _totally_ broken since it worked in https://github.com/lsst-dm/alert_database_server/pull/2. 